### PR TITLE
Widerrufsbutton: zweistufiges Widerruf-Formular + Cloudflare-Versand vorbereitet

### DIFF
--- a/cloudflare/widerruf-worker/README.md
+++ b/cloudflare/widerruf-worker/README.md
@@ -17,10 +17,39 @@ cd cloudflare/widerruf-worker
 npm install -g wrangler        # falls noch nicht vorhanden
 wrangler login
 
-# Absender/Empfänger in wrangler.toml prüfen, dann:
-wrangler secret put RESEND_API_KEY   # API-Key des E-Mail-Dienstes eingeben
+# Absender/Empfänger in wrangler.toml prüfen, dann Secrets setzen:
+wrangler secret put RESEND_API_KEY     # API-Key des E-Mail-Dienstes
+wrangler secret put TURNSTILE_SECRET   # Turnstile-Secret (Bot-Schutz, Pflicht)
 wrangler deploy
 ```
+
+## Missbrauchsschutz (wichtig!)
+
+Ohne Schutz wäre der Endpoint ein **offenes Mail-Relay**: Jeder direkte POST mit
+`name`, `email`, `orderNumber` würde Antik70-gebrandete E-Mails an beliebige
+Empfänger auslösen (Spam, Reputations- und Kostenschaden). CORS verhindert das
+**nicht** – es schützt nur Browser-Reads, keine direkten Requests.
+
+Der Worker setzt daher drei Schichten ein:
+
+1. **Origin-Prüfung** gegen `ALLOWED_ORIGIN`.
+2. **Rate-Limit pro IP** über das `RATE_LIMITER`-Binding (Standard: 5/60 s, in
+   `wrangler.toml` anpassbar; entfernen deaktiviert es).
+3. **Cloudflare Turnstile** – *fail-closed*: Ohne `TURNSTILE_SECRET` oder ohne
+   gültiges Token wird **kein** Versand ausgelöst.
+
+### Turnstile einrichten
+
+1. Im Cloudflare-Dashboard unter **Turnstile** ein Widget für `antik70.de`
+   anlegen → liefert **Sitekey** (öffentlich) und **Secret** (geheim).
+2. Secret im Worker hinterlegen: `wrangler secret put TURNSTILE_SECRET`.
+3. Sitekey im Frontend-Build als `PUBLIC_TURNSTILE_SITEKEY` setzen. Das
+   `/widerruf`-Formular blendet das Widget dann im Bestätigungsschritt ein und
+   sendet das Token mit. (Ohne Sitekey läuft das Frontend nur im
+   `mailto:`-Fallback bzw. der Worker lehnt fail-closed ab.)
+
+> Zusätzlich empfiehlt sich eine **WAF-Rate-Limiting-Regel** im Dashboard direkt
+> auf der Worker-Route als zweite Verteidigungslinie.
 
 Nach dem Deploy gibt Wrangler eine URL aus (z. B.
 `https://antik70-widerruf.<account>.workers.dev`). Diese als
@@ -42,6 +71,6 @@ Für die Kundenbestätigung wird ein externer Versanddienst benötigt.
 
 ## Sicherheit / Hinweise
 
-- `ALLOWED_ORIGIN` auf die echte Domain setzen (CORS).
-- Ggf. ein Rate-Limit / Turnstile vor den Worker schalten (Spam-Schutz).
+- `ALLOWED_ORIGIN` auf die echte Domain setzen (CORS + Origin-Prüfung).
+- `TURNSTILE_SECRET` und Rate-Limit aktiv lassen (siehe „Missbrauchsschutz“).
 - Personenbezogene Daten datensparsam behandeln (DSGVO).

--- a/cloudflare/widerruf-worker/README.md
+++ b/cloudflare/widerruf-worker/README.md
@@ -1,0 +1,47 @@
+# Widerruf-Worker (Cloudflare)
+
+Versendet die E-Mails für den Widerrufsbutton von antik70.de:
+
+1. **Benachrichtigung** an den Betreiber (`OWNER_EMAIL`)
+2. **Eingangsbestätigung** an den Kunden (mit Datum/Uhrzeit – gesetzlich vorgeschrieben)
+
+Das Frontend (statische Seite) postet das Formular per `fetch` an diesen Worker.
+Die Worker-URL wird im Frontend über die Umgebungsvariable
+`PUBLIC_WIDERRUF_ENDPOINT` gesetzt. Solange diese leer ist, greift im Frontend
+ein `mailto:`-Fallback.
+
+## Setup
+
+```bash
+cd cloudflare/widerruf-worker
+npm install -g wrangler        # falls noch nicht vorhanden
+wrangler login
+
+# Absender/Empfänger in wrangler.toml prüfen, dann:
+wrangler secret put RESEND_API_KEY   # API-Key des E-Mail-Dienstes eingeben
+wrangler deploy
+```
+
+Nach dem Deploy gibt Wrangler eine URL aus (z. B.
+`https://antik70-widerruf.<account>.workers.dev`). Diese als
+`PUBLIC_WIDERRUF_ENDPOINT` im Hosting/Build des Frontends hinterlegen.
+
+## E-Mail-Versand
+
+Das Beispiel nutzt [Resend](https://resend.com) (einfache HTTP-API). Dafür muss
+die Domain `antik70.de` einmalig bei Resend verifiziert werden (SPF/DKIM).
+Alternative Dienste mit HTTP-API funktionieren analog – nur `sendEmail()`
+in `src/index.js` anpassen.
+
+### Alternative: Cloudflare Email Routing
+
+Cloudflares native `send_email`-Bindung kann **nur an verifizierte Adressen**
+senden. Sie eignet sich daher gut für die **Betreiber-Benachrichtigung**
+(`info@antik70.de`), nicht aber für die Eingangsbestätigung an beliebige Kunden.
+Für die Kundenbestätigung wird ein externer Versanddienst benötigt.
+
+## Sicherheit / Hinweise
+
+- `ALLOWED_ORIGIN` auf die echte Domain setzen (CORS).
+- Ggf. ein Rate-Limit / Turnstile vor den Worker schalten (Spam-Schutz).
+- Personenbezogene Daten datensparsam behandeln (DSGVO).

--- a/cloudflare/widerruf-worker/src/index.js
+++ b/cloudflare/widerruf-worker/src/index.js
@@ -11,10 +11,17 @@
  * Betreiber-Benachrichtigung). Siehe README.
  *
  * Benötigte Secrets / Variablen (via `wrangler secret put` bzw. wrangler.toml):
- *   - RESEND_API_KEY   (Secret)  API-Key des E-Mail-Dienstes
- *   - FROM_EMAIL       (Var)     Absender, z. B. "Antik70 <widerruf@antik70.de>"
- *   - OWNER_EMAIL      (Var)     Postfach des Betreibers, z. B. "info@antik70.de"
- *   - ALLOWED_ORIGIN   (Var)     erlaubte Herkunft, z. B. "https://antik70.de"
+ *   - RESEND_API_KEY    (Secret)  API-Key des E-Mail-Dienstes
+ *   - TURNSTILE_SECRET  (Secret)  Cloudflare-Turnstile-Secret (Bot-Schutz, PFLICHT)
+ *   - FROM_EMAIL        (Var)     Absender, z. B. "Antik70 <widerruf@antik70.de>"
+ *   - OWNER_EMAIL       (Var)     Postfach des Betreibers, z. B. "info@antik70.de"
+ *   - ALLOWED_ORIGIN    (Var)     erlaubte Herkunft, z. B. "https://antik70.de"
+ *   - RATE_LIMITER      (Binding) optional: Workers-Rate-Limiting (siehe wrangler.toml)
+ *
+ * Missbrauchsschutz (sonst offenes Mail-Relay!):
+ *   1. Origin-Prüfung gegen ALLOWED_ORIGIN
+ *   2. optionales Rate-Limit pro IP
+ *   3. Cloudflare Turnstile (fail-closed: ohne gültiges Token kein Versand)
  */
 
 export default {
@@ -22,7 +29,8 @@ export default {
 		const cors = {
 			'Access-Control-Allow-Origin': env.ALLOWED_ORIGIN || '*',
 			'Access-Control-Allow-Methods': 'POST, OPTIONS',
-			'Access-Control-Allow-Headers': 'Content-Type'
+			'Access-Control-Allow-Headers': 'Content-Type',
+			Vary: 'Origin'
 		};
 
 		if (request.method === 'OPTIONS') {
@@ -32,11 +40,38 @@ export default {
 			return json({ error: 'Method not allowed' }, 405, cors);
 		}
 
+		// 1) Origin-Prüfung. Browser senden Origin bei Cross-Origin-POSTs; stimmt
+		// dieser nicht, sofort ablehnen. (Schützt nicht gegen Clients ohne Origin
+		// – dafür greift der Turnstile-Check unten.)
+		const origin = request.headers.get('Origin');
+		if (env.ALLOWED_ORIGIN && origin && origin !== env.ALLOWED_ORIGIN) {
+			return json({ error: 'Forbidden origin' }, 403, cors);
+		}
+
+		const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
+
+		// 2) Rate-Limit pro IP (optional, nur wenn Binding konfiguriert).
+		if (env.RATE_LIMITER) {
+			const { success } = await env.RATE_LIMITER.limit({ key: clientIp });
+			if (!success) {
+				return json({ error: 'Zu viele Anfragen. Bitte später erneut versuchen.' }, 429, cors);
+			}
+		}
+
 		let data;
 		try {
 			data = await request.json();
 		} catch {
 			return json({ error: 'Invalid JSON' }, 400, cors);
+		}
+
+		// 3) Turnstile-Verifikation – fail-closed: ohne Secret kein Versand.
+		if (!env.TURNSTILE_SECRET) {
+			return json({ error: 'Server misconfigured: TURNSTILE_SECRET fehlt' }, 500, cors);
+		}
+		const human = await verifyTurnstile(env.TURNSTILE_SECRET, data.turnstileToken, clientIp);
+		if (!human) {
+			return json({ error: 'Bot-Schutz fehlgeschlagen' }, 403, cors);
 		}
 
 		const { name, email, orderNumber } = data;
@@ -73,6 +108,21 @@ export default {
 		return json({ ok: true, receivedAt }, 200, cors);
 	}
 };
+
+async function verifyTurnstile(secret, token, ip) {
+	if (!token) return false;
+	const body = new FormData();
+	body.append('secret', secret);
+	body.append('response', token);
+	if (ip && ip !== 'unknown') body.append('remoteip', ip);
+	const res = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+		method: 'POST',
+		body
+	});
+	if (!res.ok) return false;
+	const data = await res.json();
+	return data.success === true;
+}
 
 function formatSummary(d, receivedAt) {
 	const rows = [

--- a/cloudflare/widerruf-worker/src/index.js
+++ b/cloudflare/widerruf-worker/src/index.js
@@ -1,0 +1,118 @@
+/**
+ * Cloudflare Worker für den Widerrufsbutton von antik70.de
+ *
+ * Nimmt das Widerruf-Formular (POST JSON) entgegen und versendet zwei E-Mails:
+ *   1. Benachrichtigung an den Shop-Betreiber (Widerruf eingegangen)
+ *   2. Eingangsbestätigung an den Kunden (gesetzlich vorgeschrieben, mit Datum/Uhrzeit)
+ *
+ * E-Mail-Versand erfolgt hier über die Resend-API (https://resend.com) – einfach
+ * per HTTP. Als Alternative kann die Cloudflare Email Routing "send_email"-Bindung
+ * genutzt werden (nur für verifizierte Empfänger, eignet sich für die
+ * Betreiber-Benachrichtigung). Siehe README.
+ *
+ * Benötigte Secrets / Variablen (via `wrangler secret put` bzw. wrangler.toml):
+ *   - RESEND_API_KEY   (Secret)  API-Key des E-Mail-Dienstes
+ *   - FROM_EMAIL       (Var)     Absender, z. B. "Antik70 <widerruf@antik70.de>"
+ *   - OWNER_EMAIL      (Var)     Postfach des Betreibers, z. B. "info@antik70.de"
+ *   - ALLOWED_ORIGIN   (Var)     erlaubte Herkunft, z. B. "https://antik70.de"
+ */
+
+export default {
+	async fetch(request, env) {
+		const cors = {
+			'Access-Control-Allow-Origin': env.ALLOWED_ORIGIN || '*',
+			'Access-Control-Allow-Methods': 'POST, OPTIONS',
+			'Access-Control-Allow-Headers': 'Content-Type'
+		};
+
+		if (request.method === 'OPTIONS') {
+			return new Response(null, { headers: cors });
+		}
+		if (request.method !== 'POST') {
+			return json({ error: 'Method not allowed' }, 405, cors);
+		}
+
+		let data;
+		try {
+			data = await request.json();
+		} catch {
+			return json({ error: 'Invalid JSON' }, 400, cors);
+		}
+
+		const { name, email, orderNumber } = data;
+		if (!name || !email || !orderNumber) {
+			return json({ error: 'Pflichtfelder fehlen' }, 422, cors);
+		}
+
+		const receivedAt = new Date().toLocaleString('de-DE', { timeZone: 'Europe/Berlin' });
+		const summary = formatSummary(data, receivedAt);
+
+		try {
+			// 1) Benachrichtigung an den Betreiber
+			await sendEmail(env, {
+				to: env.OWNER_EMAIL,
+				replyTo: email,
+				subject: `Neuer Widerruf – Bestellung ${orderNumber}`,
+				text: `Es ist ein Widerruf eingegangen.\n\n${summary}`
+			});
+
+			// 2) Eingangsbestätigung an den Kunden
+			await sendEmail(env, {
+				to: email,
+				subject: 'Eingangsbestätigung Ihres Widerrufs – Antik70',
+				text:
+					`Guten Tag ${name},\n\n` +
+					`wir bestätigen den Eingang Ihres Widerrufs am ${receivedAt}.\n\n` +
+					`Ihre Angaben:\n${summary}\n\n` +
+					`Bitte bewahren Sie diese Bestätigung auf.\n\nMit freundlichen Grüßen\nIhr Antik70-Team`
+			});
+		} catch (err) {
+			return json({ error: 'E-Mail-Versand fehlgeschlagen', detail: String(err) }, 502, cors);
+		}
+
+		return json({ ok: true, receivedAt }, 200, cors);
+	}
+};
+
+function formatSummary(d, receivedAt) {
+	const rows = [
+		['Name', d.name],
+		['E-Mail', d.email],
+		['Bestell-/Auftragsnummer', d.orderNumber],
+		['Bestelldatum', d.orderDate],
+		['Telefon', d.phone],
+		['Anschrift', d.address],
+		['Widerrufene Ware/Dienstleistung', d.items],
+		['Bemerkung', d.message],
+		['Eingang am', receivedAt]
+	];
+	return rows
+		.filter(([, v]) => v)
+		.map(([k, v]) => `${k}: ${v}`)
+		.join('\n');
+}
+
+async function sendEmail(env, { to, subject, text, replyTo }) {
+	const res = await fetch('https://api.resend.com/emails', {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${env.RESEND_API_KEY}`,
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify({
+			from: env.FROM_EMAIL,
+			to: [to],
+			subject,
+			text,
+			...(replyTo ? { reply_to: replyTo } : {})
+		})
+	});
+	if (!res.ok) throw new Error(`Resend ${res.status}: ${await res.text()}`);
+}
+
+function json(body, status, headers) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { 'Content-Type': 'application/json', ...headers }
+	});
+}

--- a/cloudflare/widerruf-worker/wrangler.toml
+++ b/cloudflare/widerruf-worker/wrangler.toml
@@ -1,0 +1,12 @@
+name = "antik70-widerruf"
+main = "src/index.js"
+compatibility_date = "2026-01-01"
+
+# Öffentliche Variablen (kein Geheimnis)
+[vars]
+FROM_EMAIL = "Antik70 <widerruf@antik70.de>"
+OWNER_EMAIL = "info@antik70.de"
+ALLOWED_ORIGIN = "https://antik70.de"
+
+# Secret separat setzen (nicht hier eintragen!):
+#   npx wrangler secret put RESEND_API_KEY

--- a/cloudflare/widerruf-worker/wrangler.toml
+++ b/cloudflare/widerruf-worker/wrangler.toml
@@ -8,5 +8,13 @@ FROM_EMAIL = "Antik70 <widerruf@antik70.de>"
 OWNER_EMAIL = "info@antik70.de"
 ALLOWED_ORIGIN = "https://antik70.de"
 
-# Secret separat setzen (nicht hier eintragen!):
+# Rate-Limit pro IP (optional, aber empfohlen). period: 10 oder 60 Sekunden.
+[[unsafe.bindings]]
+name = "RATE_LIMITER"
+type = "ratelimit"
+namespace_id = "1001"
+simple = { limit = 5, period = 60 }
+
+# Secrets separat setzen (nicht hier eintragen!):
 #   npx wrangler secret put RESEND_API_KEY
+#   npx wrangler secret put TURNSTILE_SECRET

--- a/src/_const.ts
+++ b/src/_const.ts
@@ -85,8 +85,26 @@ export const SITE = {
 			Informationen: [
 				{ name: 'Zahlarten & Versandkosten', href: 'https://antik70.de/shop/de/Liefer-und-Versandkosten' },
 				{ name: 'Unsere AGBs', href: 'https://antik70.de/shop/de/Unsere-AGB' },
-				{ name: 'Widerrufsrecht', href: 'https://antik70.de/shop/de/Widerrufsrecht' }
+				{ name: 'Widerrufsrecht', href: 'https://antik70.de/shop/de/Widerrufsrecht' },
+				{ name: 'Vertrag widerrufen', href: '/widerruf' }
 			]
+		},
+
+		WIDERRUF: {
+			BUTTON: 'Vertrag widerrufen',
+			CONFIRM_BUTTON: 'Widerruf verbindlich bestätigen',
+			TITLE: 'Vertrag widerrufen',
+			INTRO:
+				'Mit diesem Formular können Sie einen mit uns geschlossenen Vertrag innerhalb der Widerrufsfrist widerrufen. Bitte füllen Sie die Pflichtfelder aus. Im nächsten Schritt sehen Sie eine Zusammenfassung und bestätigen den Widerruf verbindlich. Anschließend erhalten Sie eine Eingangsbestätigung per E-Mail.',
+			REVIEW_TITLE: 'Bitte prüfen Sie Ihre Angaben',
+			REVIEW_HINT:
+				'Mit Klick auf „Widerruf verbindlich bestätigen“ erklären Sie den Widerruf des unten genannten Vertrags. Wir senden Ihnen anschließend eine Eingangsbestätigung mit Datum und Uhrzeit an die angegebene E-Mail-Adresse.',
+			SUCCESS_TITLE: 'Ihr Widerruf ist eingegangen',
+			SUCCESS_TEXT: 'Wir haben Ihren Widerruf erhalten und Ihnen eine Eingangsbestätigung per E-Mail gesendet. Bitte bewahren Sie diese Bestätigung auf.',
+			FALLBACK_TITLE: 'Bitte senden Sie uns Ihren Widerruf per E-Mail',
+			FALLBACK_TEXT:
+				'Der automatische Versand ist derzeit nicht verfügbar. Bitte senden Sie uns Ihren Widerruf über die unten vorbereitete E-Mail. Ihre Angaben sind bereits eingetragen.',
+			EMAIL_SUBJECT: 'Widerruf eines Vertrags'
 		},
 
 		OPEN_HOURS: 'Öffnungszeiten',

--- a/src/lib/components/Navigation.svelte
+++ b/src/lib/components/Navigation.svelte
@@ -7,7 +7,10 @@
 <ul class="hidden lg:flex flex-1 ml-4 xl:ml-10 items-center justify-center sm:items-center sm:justify-start space-x-2 xl:space-x-4 2xl:space-x-8 text-base xl:text-lg">
 	{#each links as { label, href } (label)}
 		<li>
-			<a class="font-semibold rounded-text px-3 py-1.5 xl:px-4 xl:py-2 hover:bg-primary hover:text-white transition-colors duration-200 ease-in-out whitespace-nowrap" {href}>
+			<a
+				class="font-semibold rounded-text px-3 py-1.5 xl:px-4 xl:py-2 hover:bg-primary hover:text-white transition-colors duration-200 ease-in-out whitespace-nowrap"
+				href={href.startsWith('#') ? `/${href}` : href}
+			>
 				{label}
 			</a>
 		</li>

--- a/src/lib/sections/Footer.svelte
+++ b/src/lib/sections/Footer.svelte
@@ -11,7 +11,7 @@
 				<ul>
 					{#each links as link}
 						<li class="text-xs md:text-base md:mb-2 last:mb-0 hover:text-highlight">
-							<a target="_blank" href={link.href}>{link.name}</a>
+							<a target={link.href.startsWith('http') ? '_blank' : undefined} href={link.href.startsWith('#') ? `/${link.href}` : link.href}>{link.name}</a>
 						</li>
 					{/each}
 				</ul>

--- a/src/routes/widerruf/+page.svelte
+++ b/src/routes/widerruf/+page.svelte
@@ -1,0 +1,249 @@
+<script lang="ts">
+	import { SITE } from '$const';
+	import { env } from '$env/dynamic/public';
+
+	const W = SITE.DE.WIDERRUF;
+
+	type Step = 'form' | 'review' | 'success' | 'fallback';
+	let step: Step = 'form';
+
+	let submitting = false;
+	let confirmedAt = '';
+	let errors: Record<string, string> = {};
+
+	let form = {
+		name: '',
+		email: '',
+		orderNumber: '',
+		orderDate: '',
+		address: '',
+		phone: '',
+		items: '',
+		message: ''
+	};
+
+	function validate(): boolean {
+		errors = {};
+		if (!form.name.trim()) errors.name = 'Bitte geben Sie Ihren Namen an.';
+		if (!form.email.trim()) errors.email = 'Bitte geben Sie Ihre E-Mail-Adresse an.';
+		else if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(form.email)) errors.email = 'Bitte geben Sie eine gültige E-Mail-Adresse an.';
+		if (!form.orderNumber.trim()) errors.orderNumber = 'Bitte geben Sie Ihre Bestell- oder Auftragsnummer an.';
+		return Object.keys(errors).length === 0;
+	}
+
+	function goToReview() {
+		if (validate()) {
+			step = 'review';
+			scrollTo({ top: 0, behavior: 'smooth' });
+		}
+	}
+
+	function buildMailtoBody(): string {
+		const lines = [
+			'Hiermit widerrufe ich den von mir abgeschlossenen Vertrag.',
+			'',
+			`Name: ${form.name}`,
+			`E-Mail: ${form.email}`,
+			`Bestell-/Auftragsnummer: ${form.orderNumber}`,
+			form.orderDate ? `Bestelldatum: ${form.orderDate}` : '',
+			form.address ? `Anschrift: ${form.address}` : '',
+			form.phone ? `Telefon: ${form.phone}` : '',
+			form.items ? `Widerrufene Ware/Dienstleistung: ${form.items}` : '',
+			form.message ? `Bemerkung: ${form.message}` : '',
+			'',
+			`Datum des Widerrufs: ${new Date().toLocaleString('de-DE')}`
+		];
+		return lines.filter((l) => l !== '').join('\n');
+	}
+
+	$: mailtoHref =
+		`mailto:${SITE.EMAIL_HREF}` + `?subject=${encodeURIComponent(W.EMAIL_SUBJECT + ' – Bestellung ' + form.orderNumber)}` + `&body=${encodeURIComponent(buildMailtoBody())}`;
+
+	async function confirm() {
+		submitting = true;
+		const submittedAt = new Date().toISOString();
+
+		// Cloudflare-Endpoint (Worker / Pages Function), der die E-Mails versendet.
+		// Wird über die Umgebungsvariable PUBLIC_WIDERRUF_ENDPOINT gesetzt.
+		// Erst hier (im Browser) gelesen, damit das Prerendern nicht fehlschlägt.
+		// Solange nicht gesetzt, greift der mailto-Fallback.
+		const endpoint = env.PUBLIC_WIDERRUF_ENDPOINT ?? '';
+
+		if (!endpoint) {
+			// Cloudflare-Versand noch nicht eingerichtet -> mailto-Fallback.
+			submitting = false;
+			step = 'fallback';
+			scrollTo({ top: 0, behavior: 'smooth' });
+			return;
+		}
+
+		try {
+			const res = await fetch(endpoint, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ ...form, submittedAt })
+			});
+			if (!res.ok) throw new Error(`HTTP ${res.status}`);
+			confirmedAt = new Date().toLocaleString('de-DE');
+			step = 'success';
+		} catch (e) {
+			// Versand fehlgeschlagen -> mailto-Fallback, damit der Widerruf nie verloren geht.
+			step = 'fallback';
+		} finally {
+			submitting = false;
+			scrollTo({ top: 0, behavior: 'smooth' });
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Antik70 – Vertrag widerrufen</title>
+	<meta name="description" content="Widerrufen Sie hier bequem online einen mit Antik70 geschlossenen Vertrag. Eingangsbestätigung per E-Mail." />
+	<meta name="robots" content="noindex" />
+</svelte:head>
+
+<main class="container max-w-3xl py-8 md:py-14">
+	<a href="/" class="text-sm text-primary/70 hover:text-highlight">&larr; Zurück zur Startseite</a>
+
+	<h1 class="font-serif text-3xl md:text-5xl text-primary mt-4 mb-2">{W.TITLE}</h1>
+
+	{#if step === 'form'}
+		<p class="prose text-primary/90 mb-8 max-w-none">{W.INTRO}</p>
+
+		<form on:submit|preventDefault={goToReview} class="grid gap-5" novalidate>
+			<div class="grid gap-1">
+				<label for="name" class="font-bold text-primary">Vor- und Nachname <span class="text-redish">*</span></label>
+				<input
+					id="name"
+					type="text"
+					autocomplete="name"
+					bind:value={form.name}
+					class="rounded-text border-2 border-primary/30 bg-white px-3 py-2 focus:border-primary outline-none"
+					class:border-redish={errors.name}
+				/>
+				{#if errors.name}<span class="text-sm text-redish">{errors.name}</span>{/if}
+			</div>
+
+			<div class="grid gap-1">
+				<label for="email" class="font-bold text-primary">E-Mail-Adresse <span class="text-redish">*</span></label>
+				<input
+					id="email"
+					type="email"
+					autocomplete="email"
+					bind:value={form.email}
+					class="rounded-text border-2 border-primary/30 bg-white px-3 py-2 focus:border-primary outline-none"
+					class:border-redish={errors.email}
+				/>
+				{#if errors.email}<span class="text-sm text-redish">{errors.email}</span>{/if}
+			</div>
+
+			<div class="grid gap-1">
+				<label for="orderNumber" class="font-bold text-primary">Bestell- / Auftragsnummer <span class="text-redish">*</span></label>
+				<input
+					id="orderNumber"
+					type="text"
+					bind:value={form.orderNumber}
+					class="rounded-text border-2 border-primary/30 bg-white px-3 py-2 focus:border-primary outline-none"
+					class:border-redish={errors.orderNumber}
+				/>
+				{#if errors.orderNumber}<span class="text-sm text-redish">{errors.orderNumber}</span>{/if}
+			</div>
+
+			<div class="grid md:grid-cols-2 gap-5">
+				<div class="grid gap-1">
+					<label for="orderDate" class="font-bold text-primary">Bestelldatum</label>
+					<input id="orderDate" type="date" bind:value={form.orderDate} class="rounded-text border-2 border-primary/30 bg-white px-3 py-2 focus:border-primary outline-none" />
+				</div>
+				<div class="grid gap-1">
+					<label for="phone" class="font-bold text-primary">Telefon (optional)</label>
+					<input
+						id="phone"
+						type="tel"
+						autocomplete="tel"
+						bind:value={form.phone}
+						class="rounded-text border-2 border-primary/30 bg-white px-3 py-2 focus:border-primary outline-none"
+					/>
+				</div>
+			</div>
+
+			<div class="grid gap-1">
+				<label for="address" class="font-bold text-primary">Anschrift (optional)</label>
+				<input
+					id="address"
+					type="text"
+					autocomplete="street-address"
+					bind:value={form.address}
+					class="rounded-text border-2 border-primary/30 bg-white px-3 py-2 focus:border-primary outline-none"
+				/>
+			</div>
+
+			<div class="grid gap-1">
+				<label for="items" class="font-bold text-primary">Widerrufene Ware / Dienstleistung (optional)</label>
+				<textarea id="items" rows="2" bind:value={form.items} class="rounded-text border-2 border-primary/30 bg-white px-3 py-2 focus:border-primary outline-none"></textarea>
+			</div>
+
+			<div class="grid gap-1">
+				<label for="message" class="font-bold text-primary">Bemerkung (optional)</label>
+				<textarea id="message" rows="3" bind:value={form.message} class="rounded-text border-2 border-primary/30 bg-white px-3 py-2 focus:border-primary outline-none"></textarea>
+			</div>
+
+			<button type="submit" class="mt-2 max-w-max text-lg shadow-lg text-white px-6 py-2.5 btn rounded-xl bg-gradient-to-tr from-primary from-60% to-[#664e43] hover:from-10%">
+				Weiter zur Bestätigung
+			</button>
+		</form>
+	{:else if step === 'review'}
+		<h2 class="font-serif text-2xl text-primary mt-4 mb-2">{W.REVIEW_TITLE}</h2>
+		<p class="text-primary/80 mb-6">{W.REVIEW_HINT}</p>
+
+		<dl class="rounded-text border-2 border-primary/20 bg-white/60 divide-y divide-primary/10">
+			{#each [['Name', form.name], ['E-Mail', form.email], ['Bestell- / Auftragsnummer', form.orderNumber], ['Bestelldatum', form.orderDate], ['Telefon', form.phone], ['Anschrift', form.address], ['Widerrufene Ware / Dienstleistung', form.items], ['Bemerkung', form.message]] as [label, value]}
+				{#if value}
+					<div class="grid grid-cols-1 md:grid-cols-3 gap-1 px-4 py-3">
+						<dt class="font-bold text-primary/70">{label}</dt>
+						<dd class="md:col-span-2 text-primary whitespace-pre-line">{value}</dd>
+					</div>
+				{/if}
+			{/each}
+		</dl>
+
+		<div class="flex flex-wrap gap-3 mt-6">
+			<button
+				type="button"
+				on:click={() => (step = 'form')}
+				class="text-base px-5 py-2.5 rounded-xl border-2 border-primary text-primary hover:bg-primary hover:text-white transition-colors"
+			>
+				Zurück / ändern
+			</button>
+			<button
+				type="button"
+				disabled={submitting}
+				on:click={confirm}
+				class="text-lg shadow-lg text-white px-6 py-2.5 btn rounded-xl bg-gradient-to-tr from-redish from-60% to-redish-LIGHT hover:from-10% disabled:opacity-60"
+			>
+				{submitting ? 'Wird gesendet …' : W.CONFIRM_BUTTON}
+			</button>
+		</div>
+	{:else if step === 'success'}
+		<div class="rounded-text border-2 border-primary/20 bg-white/70 p-6 mt-4">
+			<h2 class="font-serif text-2xl text-primary mb-2">{W.SUCCESS_TITLE}</h2>
+			<p class="text-primary/90">{W.SUCCESS_TEXT}</p>
+			{#if confirmedAt}
+				<p class="text-sm text-primary/70 mt-4">Eingang am: {confirmedAt}</p>
+			{/if}
+			<a href="/" class="inline-block mt-6 text-base px-5 py-2.5 rounded-xl border-2 border-primary text-primary hover:bg-primary hover:text-white transition-colors">
+				Zurück zur Startseite
+			</a>
+		</div>
+	{:else if step === 'fallback'}
+		<div class="rounded-text border-2 border-highlight bg-white/70 p-6 mt-4">
+			<h2 class="font-serif text-2xl text-primary mb-2">{W.FALLBACK_TITLE}</h2>
+			<p class="text-primary/90 mb-5">{W.FALLBACK_TEXT}</p>
+			<a href={mailtoHref} class="inline-block text-lg shadow-lg text-white px-6 py-2.5 btn rounded-xl bg-gradient-to-tr from-primary from-60% to-[#664e43] hover:from-10%">
+				Widerruf per E-Mail senden
+			</a>
+			<div class="mt-6">
+				<button type="button" on:click={() => (step = 'review')} class="text-base text-primary/70 hover:text-highlight underline"> Zurück zur Übersicht </button>
+			</div>
+		</div>
+	{/if}
+</main>

--- a/src/routes/widerruf/+page.svelte
+++ b/src/routes/widerruf/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { SITE } from '$const';
 	import { env } from '$env/dynamic/public';
+	import { onMount, tick } from 'svelte';
+	import { browser } from '$app/environment';
 
 	const W = SITE.DE.WIDERRUF;
 
@@ -10,6 +12,55 @@
 	let submitting = false;
 	let confirmedAt = '';
 	let errors: Record<string, string> = {};
+
+	// Cloudflare Turnstile (Bot-Schutz). Sitekey wird erst im Browser gelesen,
+	// damit das Prerendern nicht fehlschlägt. Ist kein Sitekey gesetzt, läuft
+	// der Bot-Schutz nicht – der Worker lehnt dann fail-closed ab.
+	let turnstileSitekey = '';
+	let turnstileToken = '';
+	let turnstileEl: HTMLDivElement | undefined;
+	let turnstileWidgetId: string | undefined;
+
+	onMount(() => {
+		turnstileSitekey = env.PUBLIC_TURNSTILE_SITEKEY ?? '';
+		if (turnstileSitekey) {
+			const s = document.createElement('script');
+			s.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+			s.async = true;
+			s.defer = true;
+			document.head.appendChild(s);
+		}
+	});
+
+	function renderTurnstile() {
+		if (!browser || !turnstileSitekey || !turnstileEl) return;
+		// @ts-expect-error – Turnstile injiziert window.turnstile
+		const ts = window.turnstile;
+		if (!ts) {
+			setTimeout(renderTurnstile, 200);
+			return;
+		}
+		if (turnstileWidgetId !== undefined) return;
+		turnstileWidgetId = ts.render(turnstileEl, {
+			sitekey: turnstileSitekey,
+			callback: (token: string) => (turnstileToken = token),
+			'error-callback': () => (turnstileToken = ''),
+			'expired-callback': () => (turnstileToken = '')
+		});
+	}
+
+	function resetTurnstile() {
+		// @ts-expect-error – Turnstile injiziert window.turnstile
+		const ts = browser ? window.turnstile : undefined;
+		if (ts && turnstileWidgetId !== undefined) ts.remove(turnstileWidgetId);
+		turnstileWidgetId = undefined;
+		turnstileToken = '';
+	}
+
+	// Beim Eintritt in den Bestätigungsschritt das Widget rendern.
+	$: if (step === 'review' && turnstileSitekey && turnstileWidgetId === undefined) {
+		tick().then(renderTurnstile);
+	}
 
 	let form = {
 		name: '',
@@ -38,6 +89,11 @@
 		}
 	}
 
+	function backToForm() {
+		resetTurnstile();
+		step = 'form';
+	}
+
 	function buildMailtoBody(): string {
 		const lines = [
 			'Hiermit widerrufe ich den von mir abgeschlossenen Vertrag.',
@@ -60,9 +116,6 @@
 		`mailto:${SITE.EMAIL_HREF}` + `?subject=${encodeURIComponent(W.EMAIL_SUBJECT + ' – Bestellung ' + form.orderNumber)}` + `&body=${encodeURIComponent(buildMailtoBody())}`;
 
 	async function confirm() {
-		submitting = true;
-		const submittedAt = new Date().toISOString();
-
 		// Cloudflare-Endpoint (Worker / Pages Function), der die E-Mails versendet.
 		// Wird über die Umgebungsvariable PUBLIC_WIDERRUF_ENDPOINT gesetzt.
 		// Erst hier (im Browser) gelesen, damit das Prerendern nicht fehlschlägt.
@@ -71,23 +124,32 @@
 
 		if (!endpoint) {
 			// Cloudflare-Versand noch nicht eingerichtet -> mailto-Fallback.
-			submitting = false;
 			step = 'fallback';
 			scrollTo({ top: 0, behavior: 'smooth' });
 			return;
 		}
 
+		// Bot-Schutz: ohne gelösten Turnstile keinen Versand auslösen.
+		if (turnstileSitekey && !turnstileToken) {
+			errors = { turnstile: 'Bitte bestätigen Sie, dass Sie kein Roboter sind.' };
+			return;
+		}
+
+		submitting = true;
+		const submittedAt = new Date().toISOString();
+
 		try {
 			const res = await fetch(endpoint, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ ...form, submittedAt })
+				body: JSON.stringify({ ...form, submittedAt, turnstileToken })
 			});
 			if (!res.ok) throw new Error(`HTTP ${res.status}`);
 			confirmedAt = new Date().toLocaleString('de-DE');
 			step = 'success';
 		} catch (e) {
 			// Versand fehlgeschlagen -> mailto-Fallback, damit der Widerruf nie verloren geht.
+			resetTurnstile();
 			step = 'fallback';
 		} finally {
 			submitting = false;
@@ -206,12 +268,13 @@
 			{/each}
 		</dl>
 
+		{#if turnstileSitekey}
+			<div class="mt-6" bind:this={turnstileEl}></div>
+			{#if errors.turnstile}<p class="text-sm text-redish mt-2">{errors.turnstile}</p>{/if}
+		{/if}
+
 		<div class="flex flex-wrap gap-3 mt-6">
-			<button
-				type="button"
-				on:click={() => (step = 'form')}
-				class="text-base px-5 py-2.5 rounded-xl border-2 border-primary text-primary hover:bg-primary hover:text-white transition-colors"
-			>
+			<button type="button" on:click={backToForm} class="text-base px-5 py-2.5 rounded-xl border-2 border-primary text-primary hover:bg-primary hover:text-white transition-colors">
 				Zurück / ändern
 			</button>
 			<button

--- a/src/routes/widerruf/+page.ts
+++ b/src/routes/widerruf/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;


### PR DESCRIPTION
- Neue Route /widerruf mit rechtskonformem, zweistufigem Ablauf
  (Eingabe -> Bestaetigung -> Eingangsbestaetigung), Button 'Vertrag widerrufen'
- Footer-Link 'Vertrag widerrufen' (dauerhaft erreichbar), interne Links
  oeffnen nicht mehr in neuem Tab
- Anker-Links in Navigation/Footer auf Homepage normalisiert (/#...)
- POST an konfigurierbaren Endpoint (PUBLIC_WIDERRUF_ENDPOINT) mit
  mailto-Fallback, solange Cloudflare-Versand nicht eingerichtet ist
- Beispiel-Cloudflare-Worker + Anleitung unter cloudflare/widerruf-worker

https://claude.ai/code/session_01EE9RYkApv61wNp2Wd4Fvn8